### PR TITLE
[TE-401] we (team) decided  to keep the old repository under http://d…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ bintray {
     configurations = ['archives']
     publish = true 
     pkg {
-        repo = 'maven'
+        repo = 'Fixtures'
         name = project.name
         userOrg = 'test-editor'
         websiteUrl = 'http://testeditor.org'


### PR DESCRIPTION
…l.bintray.com/test-editor/Fixtures because it is linked with JCenter already.
But we have to create a new Version 3.0.0 and V 3.0.1 of core-fixtures again at the old Repository path (mentioned above) and we have to delete the old path under http://dl.bintray.com/test-editor/maven.
